### PR TITLE
Add CSS function negation gotcha to docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -726,6 +726,10 @@ class CustomCursor {
 }
 ```
 
+**CSS Function Negation:**
+- Never negate CSS functions directly — `-clamp()`, `-min()`, `-max()` are silently ignored by browsers with no console error
+- Always use `calc(-1 * clamp(...))` instead. See STYLE_PRESETS.md → "CSS Gotchas" for details.
+
 **Responsive & Viewport Fitting (CRITICAL):**
 
 **See the "CRITICAL: Viewport Fitting Requirements" section above for complete CSS and guidelines.**

--- a/STYLE_PRESETS.md
+++ b/STYLE_PRESETS.md
@@ -157,6 +157,7 @@ Before finalizing any presentation, verify:
 - [ ] Content respects density limits (max 6 bullets, max 6 cards)
 - [ ] No fixed pixel heights on content elements
 - [ ] Images have `max-height` constraints
+- [ ] No negated CSS functions (use `calc(-1 * clamp(...))` not `-clamp(...)`)
 
 ---
 
@@ -478,6 +479,30 @@ Before finalizing any presentation, verify:
 **Layouts:** Everything centered, generic hero sections, identical card grids
 
 **Decorations:** Realistic illustrations, gratuitous glassmorphism, drop shadows without purpose
+
+---
+
+## CSS Gotchas (Common Mistakes)
+
+### Negating CSS Functions
+
+**WRONG — silently ignored by browsers:**
+```css
+right: -clamp(28px, 3.5vw, 44px);   /* ❌ Invalid! Browser ignores this */
+margin-left: -min(10vw, 100px);      /* ❌ Invalid! */
+top: -max(2rem, 4vh);                /* ❌ Invalid! */
+```
+
+**CORRECT — wrap in `calc()`:**
+```css
+right: calc(-1 * clamp(28px, 3.5vw, 44px));  /* ✅ */
+margin-left: calc(-1 * min(10vw, 100px));     /* ✅ */
+top: calc(-1 * max(2rem, 4vh));               /* ✅ */
+```
+
+CSS does not allow a leading `-` before function names like `clamp()`, `min()`, `max()`. The browser silently discards the entire declaration, causing the property to fall back to its initial/inherited value. This is especially dangerous because there is no console error — the element simply appears in the wrong position.
+
+**Rule: Always use `calc(-1 * ...)` to negate CSS function values.**
 
 ---
 


### PR DESCRIPTION
## Summary

- Browsers silently ignore CSS declarations like `right: -clamp(...)` — the leading minus before CSS functions (`clamp`, `min`, `max`) is invalid syntax
- No console error is thrown; the property simply falls back to its initial value, causing elements to appear in wrong positions
- The correct pattern is `calc(-1 * clamp(...))` 

## Changes

**STYLE_PRESETS.md:**
- Added "CSS Gotchas (Common Mistakes)" section with wrong/correct code examples
- Added checklist item to the Viewport Fitting Checklist

**SKILL.md:**
- Added "CSS Function Negation" warning under Code Quality Requirements

## How I Found This

While building preview files for presets 5 (Notebook Tabs) and 6 (Pastel Geometry), the signature elements (tabs and pills) that should protrude from the card's right edge were rendering in the wrong position. The CSS used `right: -clamp(28px, 3.5vw, 44px)` which browsers silently discarded. Switching to `right: calc(-1 * clamp(28px, 3.5vw, 44px))` fixed the positioning.

This is a subtle and dangerous pattern because:
1. There is **no console error or warning**
2. The element renders — just in the wrong place
3. It's easy to write `-clamp()` by analogy with `-10px` (which is valid)

## Test plan

- [ ] Verify the markdown renders correctly on GitHub
- [ ] Try using the `-clamp()` pattern in a browser to confirm it's ignored
- [ ] Try the `calc(-1 * clamp(...))` pattern to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)