### PR TITLE
Revise installation instructions to use skills.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,10 @@ A Claude Code skill for creating stunning, animation-rich HTML presentations —
 
 ## Installation
 
-### For Claude Code Users
-
-Copy the skill files to your Claude Code skills directory:
+### Automatic (for any coding agent)
 
 ```bash
-# Create the skill directory
-mkdir -p ~/.claude/skills/frontend-slides
-
-# Copy the files (or download from this repo)
-cp SKILL.md ~/.claude/skills/frontend-slides/
-cp STYLE_PRESETS.md ~/.claude/skills/frontend-slides/
+npx skills add zarazhangrui/frontend-slides
 ```
 
 Then use it by typing `/frontend-slides` in Claude Code.


### PR DESCRIPTION
Updated installation instructions to use automatic installation method.

Also, I suggest to create `skills` directory and put `frontend-slides` directory inside with only 2 files: `SKILL.md` and `STYLE_PRESETS.md` to install only these.
Keep README and LICENSE on the root