### PR TITLE
feat: add PDF export helper and delivery workflow

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -200,8 +200,12 @@ When converting PowerPoint files:
 
 1. **Clean up** — Delete `.claude-design/slide-previews/` if it exists
 2. **Open** — Use `open [filename].html` to launch in browser
-3. **Summarize** — Tell the user:
-   - File location, style name, slide count
+3. **Export PDF (default ON)** — Run `scripts/export-pdf.sh [filename].html` to generate `[filename].pdf`
+   - If the user asks for HTML-only delivery, skip this step
+   - If PDF export fails, still deliver HTML and explain how to retry with `CHROME_BIN`
+4. **Summarize** — Tell the user:
+   - File location(s): HTML + PDF
+   - Style name, slide count
    - Navigation: Arrow keys, Space, scroll/swipe, click nav dots
    - How to customize: `:root` CSS variables for colors, font link for typography, `.reveal` class for animations
    - If inline editing was enabled: Hover top-left corner or press E to enter edit mode, click any text to edit, Ctrl+S to save
@@ -217,3 +221,4 @@ When converting PowerPoint files:
 | [html-template.md](html-template.md) | HTML structure, JS features, code quality standards | Phase 3 (generation) |
 | [animation-patterns.md](animation-patterns.md) | CSS/JS animation snippets and effect-to-feeling guide | Phase 3 (generation) |
 | [scripts/extract-pptx.py](scripts/extract-pptx.py) | Python script for PPT content extraction | Phase 4 (conversion) |
+| [scripts/export-pdf.sh](scripts/export-pdf.sh) | Export generated HTML slides to PDF via headless Chrome/Chromium | Phase 5 (delivery) |

--- a/scripts/export-pdf.sh
+++ b/scripts/export-pdf.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: export-pdf.sh input.html [output.pdf]
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 input.html [output.pdf]" >&2
+  exit 1
+fi
+
+INPUT="$1"
+if [[ ! -f "$INPUT" ]]; then
+  echo "Input file not found: $INPUT" >&2
+  exit 1
+fi
+
+if [[ $# -ge 2 ]]; then
+  OUTPUT="$2"
+else
+  OUTPUT="${INPUT%.*}.pdf"
+fi
+
+abs_path() {
+  python3 - <<'PY' "$1"
+import os,sys
+print(os.path.abspath(sys.argv[1]))
+PY
+}
+
+INPUT_ABS="$(abs_path "$INPUT")"
+OUTPUT_ABS="$(abs_path "$OUTPUT")"
+INPUT_URL="file://${INPUT_ABS}"
+
+# Find a Chromium-based browser
+BROWSER=""
+for candidate in \
+  "${CHROME_BIN:-}" \
+  "$(command -v google-chrome || true)" \
+  "$(command -v chromium || true)" \
+  "$(command -v chromium-browser || true)" \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"; do
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    BROWSER="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$BROWSER" ]]; then
+  echo "No Chromium-based browser found. Set CHROME_BIN or install Chrome/Chromium." >&2
+  exit 1
+fi
+
+"$BROWSER" \
+  --headless \
+  --disable-gpu \
+  --run-all-compositor-stages-before-draw \
+  --virtual-time-budget=12000 \
+  --print-to-pdf="$OUTPUT_ABS" \
+  "$INPUT_URL"
+
+echo "Exported PDF: $OUTPUT_ABS"


### PR DESCRIPTION
## Summary
This PR adds a practical PDF-export path for the Frontend Slides skill so generated decks can be delivered as both HTML and PDF with minimal friction.

### What changed
- Add `scripts/export-pdf.sh`
  - Converts generated HTML slides to PDF with headless Chrome/Chromium
  - Auto-detects browser binary (`CHROME_BIN`, `google-chrome`, `chromium`, macOS Chrome path)
  - Supports optional output path
- Update `SKILL.md` delivery phase
  - Add **Export PDF (default ON)** after HTML generation
  - Clarify fallback behavior when export fails
  - Update delivery summary to include HTML + PDF
- Update supporting-files table in `SKILL.md` to document `scripts/export-pdf.sh`

## Why
Many users need a shareable PDF immediately after generating web slides. This makes delivery smoother and avoids manual export steps.

## Notes
- Existing HTML-first flow is preserved
- Users can still choose HTML-only delivery if requested
