### PR TITLE
feat: add three-phase slide hosting (local/tailscale/cloudflare)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ This skill uses **progressive disclosure** — the main `SKILL.md` is a concise 
 | `html-template.md` | HTML structure and JS features | Phase 3 (generation) |
 | `animation-patterns.md` | CSS/JS animation reference | Phase 3 (generation) |
 | `scripts/extract-pptx.py` | PPT content extraction | Phase 4 (conversion) |
+| `scripts/start-hosting.sh` | Three-phase hosting | Phase 6 (hosting) |
+| `scripts/stop-hosting.sh` | Hosting teardown | Phase 6 (hosting) |
 
 This design follows [OpenAI's harness engineering](https://openai.com/index/harness-engineering/) principle: "give the agent a map, not a 1,000-page instruction manual."
 
@@ -120,10 +122,57 @@ This skill was born from the belief that:
 
 4. **Comments are kindness.** Code should explain itself to future-you (or anyone else who opens it).
 
+## Hosting Your Slides
+
+After generating a presentation, you can host and share it with a single command:
+
+```bash
+bash scripts/start-hosting.sh
+```
+
+The script progressively enables three levels of access:
+
+| Phase | Access Level | Requirement | Behavior |
+|-------|-------------|-------------|----------|
+| **Phase 1** | 🏠 Local Network | Docker, Python 3, or Node.js | **Auto** — starts server, prints localhost + LAN IP |
+| **Phase 2** | 🔒 Tailscale | [Tailscale](https://tailscale.com/download) | **Auto** — detects & registers if available |
+| **Phase 3** | 🌍 Public | [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) | **Asks first** — creates temporary anonymous URL |
+
+```
+╔══════════════════════════════════════╗
+║     Frontend Slides Hosting          ║
+╚══════════════════════════════════════╝
+
+Phase 1: Local Network
+──────────────────────
+✓ Docker (nginx:alpine) on port 9100
+
+  http://localhost:9100/my-deck/
+  http://192.168.1.42:9100/my-deck/  (LAN / phone)
+
+Phase 2: Tailscale
+──────────────────
+✓ Tailscale Serve registered
+
+  https://my-machine.tailnet.ts.net/slides/my-deck/
+
+Phase 3: Public Access
+──────────────────────
+Expose slides publicly via Cloudflare Tunnel? [y/N] y
+✓ Cloudflare Tunnel active
+
+  https://odd-rabbit-abc123.trycloudflare.com/my-deck/
+```
+
+To stop everything: `bash scripts/stop-hosting.sh`
+
+All slides live in `~/frontend-slides/<name>/`. Add a new deck folder and it's instantly available — no restart needed.
+
 ## Requirements
 
 - [Claude Code](https://claude.ai/claude-code) CLI
 - For PPT conversion: Python with `python-pptx` library
+- For hosting: Docker (preferred), Python 3, or Node.js
 
 ## Credits
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -208,6 +208,74 @@ When converting PowerPoint files:
 
 ---
 
+## Phase 6: Hosting (Optional)
+
+After delivery, **ask the user explicitly:** *"Would you like to host and share this presentation?"*
+
+If yes, the presentation should be placed in `~/frontend-slides/<name>/` (with all assets). Then run the hosting scripts.
+
+### Output Directory
+
+When hosting is desired, output the presentation to `~/frontend-slides/<name>/` instead of the current directory:
+
+```
+~/frontend-slides/
+  my-deck/
+    index.html
+    assets/        (if any images)
+  another-deck/
+    index.html
+```
+
+### Start Hosting
+
+```bash
+bash scripts/start-hosting.sh
+```
+
+The script runs three phases automatically:
+
+**Phase 1 (Auto) — Local Network:**
+- Detects best server: `docker` (nginx:alpine) > `python3` > `npx serve`
+- Picks first free port in 9100-9199
+- Serves `~/frontend-slides/` with directory listing disabled
+- Prints localhost + LAN IP for phone/laptop access
+
+**Phase 2 (Auto) — Tailscale:**
+- Detects if Tailscale CLI is installed and connected
+- If yes: registers `tailscale serve /slides → localhost:<port>`
+- Prints `https://<tailscale-domain>/slides/<name>/`
+
+**Phase 3 (Ask) — Public via Cloudflare Tunnel:**
+- Detects if `cloudflared` is installed
+- Asks user for confirmation before exposing publicly
+- Creates a temporary anonymous public URL (`*.trycloudflare.com`)
+- Directory listing is disabled — visitors need the exact slide URL
+
+### Stop Hosting
+
+```bash
+bash scripts/stop-hosting.sh
+```
+
+Tears down all three phases in reverse: kills Cloudflare tunnel, unregisters Tailscale Serve, stops the local server.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SLIDES_DIR` | `~/frontend-slides` | Root directory for all slide decks |
+
+### Prerequisites
+
+| Phase | Required | Install |
+|-------|----------|---------|
+| Phase 1 | Docker OR Python 3 OR Node.js | Any one of these |
+| Phase 2 | Tailscale | [tailscale.com/download](https://tailscale.com/download) |
+| Phase 3 | cloudflared | `brew install cloudflared` |
+
+---
+
 ## Supporting Files
 
 | File | Purpose | When to Read |
@@ -217,3 +285,5 @@ When converting PowerPoint files:
 | [html-template.md](html-template.md) | HTML structure, JS features, code quality standards | Phase 3 (generation) |
 | [animation-patterns.md](animation-patterns.md) | CSS/JS animation snippets and effect-to-feeling guide | Phase 3 (generation) |
 | [scripts/extract-pptx.py](scripts/extract-pptx.py) | Python script for PPT content extraction | Phase 4 (conversion) |
+| [scripts/start-hosting.sh](scripts/start-hosting.sh) | Three-phase hosting launcher | Phase 6 (hosting) |
+| [scripts/stop-hosting.sh](scripts/stop-hosting.sh) | Hosting teardown | Phase 6 (hosting) |

--- a/scripts/start-hosting.sh
+++ b/scripts/start-hosting.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# start-hosting.sh — Three-phase slide hosting
+# Phase 1 (Auto): Local network via docker/python/node
+# Phase 2 (Auto): Tailscale Serve (if available)
+# Phase 3 (Ask):  Cloudflare Tunnel (if available + user confirms)
+set -euo pipefail
+
+SLIDES_DIR="${SLIDES_DIR:-$HOME/frontend-slides}"
+PORT_RANGE_START=9100
+PORT_RANGE_END=9199
+STATE_FILE="$SLIDES_DIR/.hosting-state"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}ℹ${NC} $*"; }
+ok()    { echo -e "${GREEN}✓${NC} $*"; }
+warn()  { echo -e "${YELLOW}⚠${NC} $*"; }
+err()   { echo -e "${RED}✗${NC} $*"; }
+
+# ─── Helpers ───────────────────────────────────────────────
+
+find_free_port() {
+    for port in $(seq $PORT_RANGE_START $PORT_RANGE_END); do
+        if ! lsof -i :"$port" &>/dev/null; then
+            echo "$port"
+            return 0
+        fi
+    done
+    err "No free port found in range $PORT_RANGE_START-$PORT_RANGE_END"
+    exit 1
+}
+
+get_lan_ip() {
+    # macOS
+    if command -v ipconfig &>/dev/null; then
+        ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "unknown"
+        return 0
+    fi
+    # Linux
+    if command -v hostname &>/dev/null; then
+        hostname -I 2>/dev/null | awk '{print $1}' || echo "unknown"
+        return 0
+    fi
+    echo "unknown"
+}
+
+detect_tailscale() {
+    # macOS app location
+    local ts_cli="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+    if [[ -x "$ts_cli" ]]; then
+        echo "$ts_cli"
+        return 0
+    fi
+    # Standard PATH
+    if command -v tailscale &>/dev/null; then
+        echo "tailscale"
+        return 0
+    fi
+    return 1
+}
+
+get_tailscale_domain() {
+    local ts_cli="$1"
+    local domain
+    # Try python parsing first (reliable), fall back to grep
+    domain=$("$ts_cli" status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('Self',{}).get('DNSName',''))" 2>/dev/null | sed 's/\.$//')
+    if [[ -z "$domain" ]]; then
+        domain=$("$ts_cli" status --json 2>/dev/null | grep -o '"DNSName":"[^"]*"' | head -1 | cut -d'"' -f4 | sed 's/\.$//')
+    fi
+    echo "$domain"
+}
+
+save_state() {
+    cat > "$STATE_FILE" << EOF
+PORT=$PORT
+SERVER_TYPE=$SERVER_TYPE
+SERVER_PID=${SERVER_PID:-}
+CONTAINER_NAME=${CONTAINER_NAME:-}
+TAILSCALE_REGISTERED=${TAILSCALE_REGISTERED:-false}
+TAILSCALE_CLI=${TAILSCALE_CLI:-}
+CLOUDFLARE_PID=${CLOUDFLARE_PID:-}
+EOF
+}
+
+# ─── Pre-flight ────────────────────────────────────────────
+
+if [[ ! -d "$SLIDES_DIR" ]]; then
+    info "Creating slides directory: $SLIDES_DIR"
+    mkdir -p "$SLIDES_DIR"
+fi
+
+SLIDE_COUNT=$(find "$SLIDES_DIR" -maxdepth 2 -name "index.html" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$SLIDE_COUNT" -eq 0 ]]; then
+    warn "No slide decks found in $SLIDES_DIR"
+    warn "Add folders with index.html files, e.g.: $SLIDES_DIR/my-deck/index.html"
+fi
+
+# Check if already running
+if [[ -f "$STATE_FILE" ]]; then
+    warn "Hosting appears to be running already. Run stop-hosting.sh first."
+    exit 1
+fi
+
+PORT=$(find_free_port)
+LAN_IP=$(get_lan_ip)
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║     Frontend Slides Hosting           ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
+echo ""
+
+# ─── Phase 1: Local Network ───────────────────────────────
+
+echo -e "${BOLD}Phase 1: Local Network${NC}"
+echo "─────────────────────"
+
+if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+    SERVER_TYPE="docker"
+    CONTAINER_NAME="slides-server-$PORT"
+
+    # Write nginx config (no directory listing)
+    NGINX_CONF="$SLIDES_DIR/.nginx.conf"
+    cat > "$NGINX_CONF" << 'NGINX'
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    autoindex off;
+
+    location / {
+        try_files $uri $uri/index.html =404;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 7d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # HTML: revalidate
+    location ~* \.html$ {
+        expires 1h;
+        add_header Cache-Control "public, must-revalidate";
+    }
+}
+NGINX
+
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        -p "$PORT:80" \
+        -v "$SLIDES_DIR:/usr/share/nginx/html:ro" \
+        -v "$NGINX_CONF:/etc/nginx/conf.d/default.conf:ro" \
+        nginx:alpine &>/dev/null
+
+    ok "Docker (nginx:alpine) on port $PORT"
+
+elif command -v python3 &>/dev/null; then
+    SERVER_TYPE="python"
+    cd "$SLIDES_DIR"
+    python3 -m http.server "$PORT" --bind 0.0.0.0 &>/dev/null &
+    SERVER_PID=$!
+    ok "Python http.server on port $PORT (PID: $SERVER_PID)"
+
+elif command -v npx &>/dev/null; then
+    SERVER_TYPE="node"
+    npx -y serve "$SLIDES_DIR" -l "$PORT" --no-clipboard &>/dev/null &
+    SERVER_PID=$!
+    ok "Node serve on port $PORT (PID: $SERVER_PID)"
+
+else
+    err "No server available. Install docker, python3, or node."
+    exit 1
+fi
+
+echo ""
+info "Local access:"
+echo "    http://localhost:$PORT/"
+echo "    http://127.0.0.1:$PORT/"
+if [[ "$LAN_IP" != "unknown" ]]; then
+    echo "    http://$LAN_IP:$PORT/  (LAN / phone)"
+fi
+
+if [[ "$SLIDE_COUNT" -gt 0 ]]; then
+    echo ""
+    info "Hosted slides:"
+    find "$SLIDES_DIR" -maxdepth 2 -name "index.html" | while read -r f; do
+        name=$(basename "$(dirname "$f")")
+        [[ "$name" == "frontend-slides" ]] && continue
+        echo "    http://localhost:$PORT/$name/"
+    done
+fi
+
+# ─── Phase 2: Tailscale ───────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Phase 2: Tailscale${NC}"
+echo "──────────────────"
+
+TAILSCALE_REGISTERED=false
+TAILSCALE_CLI=""
+
+if TS_CLI=$(detect_tailscale); then
+    TAILSCALE_CLI="$TS_CLI"
+    TS_DOMAIN=$(get_tailscale_domain "$TS_CLI")
+
+    if [[ -n "$TS_DOMAIN" ]]; then
+        "$TS_CLI" serve --bg --set-path /slides "http://localhost:$PORT" 2>&1 || true
+        TAILSCALE_REGISTERED=true
+        ok "Tailscale Serve registered"
+        echo ""
+        info "Tailnet access:"
+        echo "    https://$TS_DOMAIN/slides/"
+
+        if [[ "$SLIDE_COUNT" -gt 0 ]]; then
+            find "$SLIDES_DIR" -maxdepth 2 -name "index.html" | while read -r f; do
+                name=$(basename "$(dirname "$f")")
+                [[ "$name" == "frontend-slides" ]] && continue
+                echo "    https://$TS_DOMAIN/slides/$name/"
+            done
+        fi
+    else
+        warn "Tailscale installed but not connected. Skipping."
+    fi
+else
+    info "Tailscale not found. Skipping. (Install: https://tailscale.com/download)"
+fi
+
+# ─── Phase 3: Cloudflare Tunnel ───────────────────────────
+
+echo ""
+echo -e "${BOLD}Phase 3: Public Access${NC}"
+echo "──────────────────────"
+
+CLOUDFLARE_PID=""
+
+if command -v cloudflared &>/dev/null; then
+    echo ""
+    echo -e "${YELLOW}Would you like to expose your slides publicly via Cloudflare Tunnel?${NC}"
+    echo "This will create a temporary public URL (anonymous, no account needed)."
+    echo "Directory listing is disabled — visitors need the exact slide URL."
+    echo ""
+    read -rp "Expose slides publicly? [y/N] " cf_answer
+
+    if [[ "$cf_answer" =~ ^[Yy]$ ]]; then
+        info "Starting Cloudflare Tunnel..."
+        cloudflared tunnel --url "http://localhost:$PORT" &>/tmp/cloudflared-slides.log &
+        CLOUDFLARE_PID=$!
+
+        # Wait for URL to appear in logs
+        for i in $(seq 1 15); do
+            CF_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' /tmp/cloudflared-slides.log 2>/dev/null | head -1)
+            if [[ -n "$CF_URL" ]]; then
+                break
+            fi
+            sleep 1
+        done
+
+        if [[ -n "${CF_URL:-}" ]]; then
+            ok "Cloudflare Tunnel active"
+            echo ""
+            info "Public access:"
+            echo "    $CF_URL/"
+
+            if [[ "$SLIDE_COUNT" -gt 0 ]]; then
+                find "$SLIDES_DIR" -maxdepth 2 -name "index.html" | while read -r f; do
+                    name=$(basename "$(dirname "$f")")
+                    [[ "$name" == "frontend-slides" ]] && continue
+                    echo "    $CF_URL/$name/"
+                done
+            fi
+        else
+            warn "Tunnel started but URL not detected yet. Check /tmp/cloudflared-slides.log"
+        fi
+    else
+        info "Skipped public access."
+    fi
+else
+    info "cloudflared not found. Skipping. (Install: brew install cloudflared)"
+fi
+
+# ─── Save state ───────────────────────────────────────────
+
+save_state
+
+echo ""
+echo "─────────────────────────────────────"
+ok "Hosting is running. Use ${BOLD}stop-hosting.sh${NC} to tear down."
+echo ""

--- a/scripts/start-hosting.sh
+++ b/scripts/start-hosting.sh
@@ -254,8 +254,8 @@ if command -v cloudflared &>/dev/null; then
         CLOUDFLARE_PID=$!
 
         # Wait for URL to appear in logs
-        for i in $(seq 1 15); do
-            CF_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' /tmp/cloudflared-slides.log 2>/dev/null | head -1)
+        for i in $(seq 1 30); do
+            CF_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' /tmp/cloudflared-slides.log 2>/dev/null | head -1 || true)
             if [[ -n "$CF_URL" ]]; then
                 break
             fi

--- a/scripts/stop-hosting.sh
+++ b/scripts/stop-hosting.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# stop-hosting.sh — Tear down all hosting phases
+set -euo pipefail
+
+SLIDES_DIR="${SLIDES_DIR:-$HOME/frontend-slides}"
+STATE_FILE="$SLIDES_DIR/.hosting-state"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+info() { echo -e "${CYAN}ℹ${NC} $*"; }
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    warn "No hosting state found at $STATE_FILE"
+    warn "Nothing to stop."
+    exit 0
+fi
+
+source "$STATE_FILE"
+
+echo ""
+echo -e "${BOLD}Stopping Frontend Slides Hosting${NC}"
+echo "════════════════════════════════════"
+
+# ─── Phase 3: Cloudflare Tunnel ───────────────────────────
+
+if [[ -n "${CLOUDFLARE_PID:-}" ]]; then
+    if kill "$CLOUDFLARE_PID" 2>/dev/null; then
+        ok "Cloudflare Tunnel stopped (PID: $CLOUDFLARE_PID)"
+    else
+        warn "Cloudflare Tunnel process $CLOUDFLARE_PID already gone"
+    fi
+    rm -f /tmp/cloudflared-slides.log
+fi
+
+# ─── Phase 2: Tailscale Serve ─────────────────────────────
+
+if [[ "${TAILSCALE_REGISTERED:-false}" == "true" && -n "${TAILSCALE_CLI:-}" ]]; then
+    if "$TAILSCALE_CLI" serve --set-path /slides off 2>/dev/null; then
+        ok "Tailscale Serve unregistered (/slides)"
+    else
+        warn "Failed to unregister Tailscale Serve (may already be removed)"
+    fi
+fi
+
+# ─── Phase 1: Local Server ───────────────────────────────
+
+case "${SERVER_TYPE:-}" in
+    docker)
+        if docker stop "${CONTAINER_NAME:-slides-server}" &>/dev/null; then
+            docker rm "${CONTAINER_NAME:-slides-server}" &>/dev/null
+            ok "Docker container ${CONTAINER_NAME:-slides-server} stopped and removed"
+        else
+            warn "Docker container ${CONTAINER_NAME:-slides-server} already gone"
+        fi
+        # Clean up nginx config
+        rm -f "$SLIDES_DIR/.nginx.conf"
+        ;;
+    python|node)
+        if [[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null; then
+            ok "Server stopped (PID: $SERVER_PID)"
+        else
+            warn "Server process ${SERVER_PID:-unknown} already gone"
+        fi
+        ;;
+    *)
+        warn "Unknown server type: ${SERVER_TYPE:-none}"
+        ;;
+esac
+
+# ─── Cleanup ──────────────────────────────────────────────
+
+rm -f "$STATE_FILE"
+
+echo ""
+ok "All hosting stopped."
+echo ""


### PR DESCRIPTION
## What This PR Does

Adds a hosting extension to frontend-slides — so after generating a presentation, you can instantly share it with a single command.

### Three Progressive Phases

| Phase | Access Level | Behavior |
|-------|-------------|----------|
| **Phase 1** | 🏠 Local Network | **Auto** — detects best server (docker > python > node), picks free port, prints localhost + LAN IP |
| **Phase 2** | 🔒 Tailscale | **Auto** — detects Tailscale, registers `tailscale serve /slides` |
| **Phase 3** | 🌍 Public | **Asks first** — Cloudflare Tunnel for temporary anonymous URL |

### Usage

```bash
# Start all phases
bash scripts/start-hosting.sh

# Stop everything
bash scripts/stop-hosting.sh
```

Slides live in `~/frontend-slides/<name>/`. Drop a new folder in and it's instantly available — no restart needed.

### Files Changed

- `scripts/start-hosting.sh` — Three-phase launcher with auto-detection
- `scripts/stop-hosting.sh` — Clean teardown of all phases
- `SKILL.md` — New Phase 6: Hosting section
- `README.md` — Hosting docs with example output

### Design Decisions

- **Server preference:** Docker (nginx:alpine, 7MB) > Python > Node — Docker gives caching headers + disabled directory listing out of the box
- **Phase 3 asks first** — never auto-exposes to public internet
- **State file** (`.hosting-state`) tracks what's running so teardown is clean
- **No config files needed** — nginx.conf is auto-generated at startup, cleaned up on stop

### Tested

- Phase 1 (Docker): ✅ serves HTML + assets on auto-selected port
- Phase 2 (Tailscale): ✅ auto-detects CLI, registers serve path
- Directory listing: ✅ disabled (404 on root)
- Teardown: ✅ container removed, Tailscale unregistered, state cleaned