### PR TITLE
feat: add async font loading for faster page render

### DIFF
--- a/html-template.md
+++ b/html-template.md
@@ -13,7 +13,11 @@ Reference architecture for generating slide presentations. Every presentation fo
     <title>Presentation Title</title>
 
     <!-- Fonts: use Fontshare or Google Fonts — never system fonts -->
-    <link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=..." />
+    <!-- Async loading prevents render blocking for faster page load -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=..." media="print" onload="this.media='all'" />
+    <noscript><link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=..." /></noscript>
 
     <style>
       /* ===========================================


### PR DESCRIPTION
Google Fonts/Fontshare synchronous loading blocks page rendering. Use media="print" onload trick for non-blocking async load with preconnect hints. Includes noscript fallback for JS-disabled environments.