### PR TITLE
fix: add missing skills field to plugin.json — plugin loads 0 skills on install

### DIFF
--- a/plugins/frontend-slides/.claude-plugin/plugin.json
+++ b/plugins/frontend-slides/.claude-plugin/plugin.json
@@ -9,5 +9,6 @@
   "homepage": "https://github.com/zarazhangrui/frontend-slides",
   "repository": "https://github.com/zarazhangrui/frontend-slides",
   "license": "MIT",
-  "keywords": ["presentations", "slides", "html", "design", "powerpoint", "animations"]
+  "keywords": ["presentations", "slides", "html", "design", "powerpoint", "animations"],
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Problem

After installing this plugin via the Claude Code marketplace, running `/reload-plugins` shows **0 skills**. The `/frontend-slides` skill never activates.

**Root cause:** `plugin.json` is missing the `"skills"` field. Without it, the Claude Code plugin installer doesn't know where to find skill files and skips registration entirely.

This affects every user who installs the plugin. Confirmed broken on Claude Code with the current marketplace version.

Related issues: #60, #63, #64, #51

## Fix

Add one line to `plugin.json`:

```json
"skills": "./skills/"
```

## Before / After

**Before:** Install plugin → `/reload-plugins` → `frontend-slides: 0 skills` → `/frontend-slides` does nothing

**After:** Install plugin → `/reload-plugins` → `frontend-slides: 1 skill` → `/frontend-slides` activates normally

## Testing

Tested by installing the plugin locally and verifying `/reload-plugins` registers the skill. The `"skills"` field is the standard Claude Code plugin mechanism — without it, skills are invisible to the runtime.

## Existing PRs

- #35 (open) reorganizes files into the skills directory but does not add the `skills` field to `plugin.json` — the underlying registration bug remains unfixed.
- No other PR addresses this specific missing field.