### PR TITLE
fix: add allowed-tools frontmatter so AskUserQuestion works in Claude Code

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
+allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 ---
 
 # Frontend Slides


### PR DESCRIPTION
## Problem

In newer versions of Claude Code, skills cannot use tools like `AskUserQuestion` unless they are explicitly declared in the `allowed-tools` frontmatter field. Without this, the skill runs in a restricted environment where interactive questions silently fail.

This means the presentation design phase — where the skill asks users to choose themes, color schemes, and visual styles — stops working entirely.

## Fix

Add one line to the `SKILL.md` frontmatter:

```yaml
allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
```

## Relation to PR #37

PR #37 (open) addresses the same symptom by clarifying text references in the skill body. This PR takes the correct approach: adding the YAML frontmatter that Claude Code enforces at the runtime permission level. Both could coexist but this fix addresses the root cause.

## Testing

Tested locally: after adding this frontmatter, `AskUserQuestion` invocations in the skill correctly present multiple-choice prompts to the user. Without it, the tool calls are silently skipped.