### PR TITLE
fix: prevent unstyled lines and theme corruption in inline edit mode

### DIFF
--- a/html-template.md
+++ b/html-template.md
@@ -317,6 +317,38 @@ exportFile() {
 }
 ```
 
+### Inline Edit — Enter Key & Paste Fix
+
+When `contenteditable` is active on elements inside a themed `<div>` or `<section>`, pressing Enter inserts a `<div>` (Chrome default) instead of a `<br>`, which inherits none of the element's styles and makes the new line appear unstyled. Pasting rich text injects foreign fonts and colors that override the theme.
+
+Add these three guards to every inline-editing implementation:
+
+```javascript
+// 1. Force <br> on Enter instead of <div>
+document.execCommand('defaultParagraphSeparator', false, 'br');
+
+// 2. Intercept Enter to prevent the browser default <div> insertion
+document.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && document.querySelector('[contenteditable]:focus')) {
+        e.preventDefault();
+        document.execCommand('insertLineBreak');
+    }
+});
+
+// 3. Strip rich-text formatting on paste — keep plain text only
+document.addEventListener('paste', e => {
+    const active = document.activeElement;
+    if (!active?.isContentEditable) return;
+    e.preventDefault();
+    const text = e.clipboardData.getData('text/plain');
+    document.execCommand('insertText', false, text);
+});
+```
+
+Without these fixes: after pressing Enter, new lines render with no theme font or color (issue #49); pasting from a browser or document injects foreign styles that break the theme.
+
+---
+
 ## Image Pipeline (Skip If No Images)
 
 If user chose "No images" in Phase 1, skip this entirely. If images were provided, process them before generating HTML.


### PR DESCRIPTION
## Problem

Two bugs affect the inline editing mode (issue #49):

1. **Enter key inserts unstyled `<div>`** — Chrome's default `contenteditable` behavior on Enter is to insert a `<div>`. This div inherits none of the element's CSS (font, color, line-height). The new line renders plain, looking completely different from the rest of the slide.

2. **Paste injects foreign styles** — Pasting from a browser, doc editor, or another tab injects inline `style` attributes with foreign fonts and colors. The pasted text permanently overrides the theme until the user manually removes the styles.

Both issues reproduce every time a user edits text in the generated presentation.

Closes #49.

## Fix

Three guards added to the inline editing section:

1. `document.execCommand('defaultParagraphSeparator', false, 'br')` — changes the default separator
2. `keydown` handler that intercepts `Enter` and calls `insertLineBreak` instead
3. `paste` handler that strips to plain text via `clipboardData.getData('text/plain')`

## Existing PRs

No open PR addresses this. Issue #49 has been open since 2026-04-11 with no fix submitted.