### PR TITLE
feat: mobile-friendly defaults in viewport-base.css

### DIFF
--- a/html-template.md
+++ b/html-template.md
@@ -159,6 +159,25 @@ Reference architecture for generating slide presentations. Every presentation fo
 </html>
 ```
 
+## Mobile Layout Conventions
+
+`viewport-base.css` provides several mobile-friendly defaults at `max-width: 600px`. Decks that follow these naming conventions get touch-friendly behavior automatically — no extra media queries needed:
+
+- **`.nav-dots`** — relocates from right-edge vertical rail to a centered bottom-bar pill with backdrop-blur. Ergonomic for one-handed swiping; doesn't overlap content at narrow widths.
+- **`pre`, `code`, `.code-block`, `.terminal`, `.term`** — long URLs and command lines wrap (`overflow-wrap: anywhere`) instead of blowing out the viewport.
+- **`.two-col`, `.compare`, `.side-by-side`, `.cards-2x2`, `.cards-grid`** — multi-column grids collapse to a single column.
+
+When designing dense slides (quote stacks, paired diff blocks, four-card overviews), also shrink monospace font sizes for phones explicitly via `clamp()`:
+
+```css
+@media (max-width: 600px) {
+    .code-block { font-size: clamp(0.66rem, 2.6vw, 0.78rem); }
+    .quote-card .quote-en { font-size: clamp(0.74rem, 2.4vw, 0.88rem); }
+}
+```
+
+`viewport-base.css` uses `!important` on its mobile overrides because preset CSS is inlined *after* the base file — without `!important`, equal-specificity selectors in your preset would silently win. Don't fight this: skip writing mobile-position overrides for `.nav-dots` in your preset and let the base handle it.
+
 ## Required JavaScript Features
 
 Every presentation must include:

--- a/viewport-base.css
+++ b/viewport-base.css
@@ -109,9 +109,11 @@ img, .image-container {
         --body-size: clamp(0.7rem, 1.2vw, 0.95rem);
     }
 
-    /* Hide non-essential elements */
+    /* Hide non-essential elements.
+       !important needed because preset CSS is inlined after
+       this file and would otherwise win on equal specificity. */
     .nav-dots, .keyboard-hint, .decorative {
-        display: none;
+        display: none !important;
     }
 }
 
@@ -136,6 +138,70 @@ img, .image-container {
         grid-template-columns: 1fr;
     }
 }
+
+/* ===========================================
+   MOBILE PATTERNS
+   Touch-friendly defaults for phones / narrow viewports.
+   Uses !important because preset CSS is inlined AFTER this
+   file and would otherwise win on equal specificity.
+   =========================================== */
+
+/* Long URLs, file paths, and code lines must wrap so they
+   don't blow out the slide horizontally on phones. */
+@media (max-width: 600px) {
+    pre, code,
+    .code-block, .code-block .line,
+    .terminal, .term {
+        overflow-wrap: anywhere !important;
+        word-break: break-word;
+    }
+}
+
+/* Nav dots: vertical right-rail on desktop becomes a
+   horizontal bottom-bar pill on phones. This is more
+   ergonomic for one-handed swiping and stops the rail
+   from overlapping content at narrow widths. */
+@media (max-width: 600px) {
+    .nav-dots {
+        position: fixed !important;
+        left: 50% !important;
+        right: auto !important;
+        top: auto !important;
+        bottom: clamp(0.6rem, 2vh, 1.2rem) !important;
+        transform: translateX(-50%) !important;
+        flex-direction: row !important;
+        gap: clamp(0.35rem, 1.5vw, 0.6rem) !important;
+        padding: clamp(0.35rem, 1vh, 0.55rem) clamp(0.6rem, 2vw, 0.9rem) !important;
+        background: rgba(0, 0, 0, 0.4);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        border-radius: 999px !important;
+        z-index: 90;
+    }
+}
+
+/* Common density-heavy layout classes collapse to one
+   column on phones. Decks that use these conventional
+   class names get mobile-stacking for free.
+   `grid-template-rows: auto` resets any explicit row
+   definitions (e.g. `repeat(2, 1fr)` on a 2x2 grid) so
+   stacked items size to their content instead of being
+   squeezed into the original row count. */
+@media (max-width: 600px) {
+    .two-col,
+    .compare,
+    .side-by-side,
+    .cards-2x2,
+    .cards-grid {
+        grid-template-columns: 1fr !important;
+        grid-template-rows: auto !important;
+    }
+}
+
+/* Very short viewports already hide nav-dots via the
+   max-height: 600 rule above; that takes precedence
+   over this bottom-bar layout — landscape-phones stay
+   un-cluttered. */
 
 /* ===========================================
    REDUCED MOTION


### PR DESCRIPTION
## Summary

Generated decks render on phones but with two ergonomic issues:

1. `.nav-dots` is positioned as a right-edge vertical rail on every deck I've seen — it overlaps content at narrow widths and is awkward to reach one-handed.
2. Long URLs / file paths / command lines in `.code-block` / `.terminal` blow out the slide horizontally because nothing forces them to wrap.

This adds a **Mobile Patterns** section to `viewport-base.css` at `max-width: 600px` that:

- Relocates `.nav-dots` to a centered bottom-bar pill with backdrop-blur (more ergonomic for swipe nav).
- Forces `overflow-wrap: anywhere` on `pre` / `code` / `.code-block` / `.terminal` / `.term` so long lines wrap.
- Stacks common layout classes (`.two-col`, `.compare`, `.side-by-side`, `.cards-2x2`, `.cards-grid`) to a single column, with `grid-template-rows: auto` reset so stacked items size to content instead of being squeezed into the original row count.

`html-template.md` gains a **Mobile Layout Conventions** section documenting these class names so future generators lean on the base.

## Why `!important`?

Preset CSS is inlined *after* `viewport-base.css` in every generated deck. Without `!important`, equal-specificity selectors in the preset (e.g. a preset that styles `.nav-dots { position: fixed; right: 1rem; top: 50%; ... }` with no `@media` wrapper) silently win at all viewports, including phone widths.

This also fixes a **pre-existing latent bug**: the `max-height: 600px` rule that hides `.nav-dots` / `.keyboard-hint` / `.decorative` never actually fires in practice, because the preset's later non-media `.nav-dots` rule overrides the base's `display: none`. Adding `!important` there makes it work as intended.

I added a short note in `html-template.md` explaining this so future contributors don't write competing position rules in their presets.

## Verification

Tested on iPhone 14 (390×844) and iPhone SE (375×667) viewports with a Terminal Green style 16-slide deck. Before/after across cover, tweet card, 4-card overview (the 2×2 → 1×4 case), 2-col rule layouts, and side-by-side bad/good diff layouts. All density-heavy patterns now fit cleanly in viewport with the bottom-bar nav reachable.

## Test plan

- [ ] Regenerate a deck through the skill at desktop width — should be unchanged from current behavior.
- [ ] Open the generated deck at 390×844 in DevTools mobile emulator:
  - [ ] `.nav-dots` appears as a horizontal pill at the bottom, not a right-edge rail.
  - [ ] Long URLs in any code block wrap instead of overflowing.
  - [ ] Any `.two-col` / `.compare` / `.cards-2x2` slides stack to a single column with full content visible (no clipping).
- [ ] Open at 800×500 (landscape phone) — nav-dots should be hidden by the `max-height: 600` rule (which now actually fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)