### PR TITLE
fix: restore slide touch and wheel navigation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -264,7 +264,7 @@ When converting PowerPoint files:
 2. **Open** — Use `open [filename].html` to launch in browser
 3. **Summarize** — Tell the user:
    - File location, style name, slide count
-   - Navigation: Arrow keys, Space, swipe/tap if enabled
+   - Navigation: Arrow keys, Space, short mouse wheel, horizontal swipe, and tap zones
    - How to customize: `:root` CSS variables for colors, font link for typography, `.reveal` class for animations
    - Inline text editing is available: Hover top-left corner or press E to enter edit mode, click any text to edit, Ctrl+S to save
    - Offer the natural post-draft actions: ask for revisions, edit text directly in the browser, or export/share

--- a/bold-template-pack/deck-stage.js
+++ b/bold-template-pack/deck-stage.js
@@ -30,7 +30,7 @@
  *     e.detail.total         // total slide count
  *     e.detail.slide         // the new active slide element
  *     e.detail.previousSlide // the prior slide element, or null on init
- *     e.detail.reason        // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+ *     e.detail.reason        // 'init' | 'keyboard' | 'wheel' | 'click' | 'tap' | 'swipe' | 'api'
  *   });
  *
  * Persistence: none at the deck level. The host app keeps the current slide
@@ -53,6 +53,12 @@
   const DESIGN_W_DEFAULT = 1920;
   const DESIGN_H_DEFAULT = 1080;
   const OVERLAY_HIDE_MS = 1800;
+  const SWIPE_THRESHOLD_PX = 48;
+  const SWIPE_RESTRAINT_PX = 80;
+  const SWIPE_MAX_TIME_MS = 1200;
+  const WHEEL_THRESHOLD_PX = 30;
+  const WHEEL_COOLDOWN_MS = 450;
+  const WHEEL_RESET_MS = 180;
   const VALIDATE_ATTR = 'no_overflowing_text,no_overlapping_text,slide_sized_text';
 
   const pad2 = (n) => String(n).padStart(2, '0');
@@ -66,6 +72,8 @@
       color: #fff;
       font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
       overflow: hidden;
+      overscroll-behavior: none;
+      touch-action: pan-y;
     }
 
     .stage {
@@ -276,11 +284,25 @@
       this._notes = [];
       this._hideTimer = null;
       this._mouseIdleTimer = null;
+      this._wheelAccum = 0;
+      this._lastWheelTime = 0;
+      this._wheelResetTimer = null;
+      this._touchTracking = false;
+      this._touchStartX = 0;
+      this._touchStartY = 0;
+      this._touchLastX = 0;
+      this._touchLastY = 0;
+      this._touchStartTime = 0;
 
       this._onKey = this._onKey.bind(this);
       this._onResize = this._onResize.bind(this);
       this._onSlotChange = this._onSlotChange.bind(this);
       this._onMouseMove = this._onMouseMove.bind(this);
+      this._onWheel = this._onWheel.bind(this);
+      this._onTouchStart = this._onTouchStart.bind(this);
+      this._onTouchMove = this._onTouchMove.bind(this);
+      this._onTouchEnd = this._onTouchEnd.bind(this);
+      this._onTouchCancel = this._onTouchCancel.bind(this);
       this._onTapBack = this._onTapBack.bind(this);
       this._onTapForward = this._onTapForward.bind(this);
     }
@@ -299,6 +321,11 @@
       window.addEventListener('keydown', this._onKey);
       window.addEventListener('resize', this._onResize);
       window.addEventListener('mousemove', this._onMouseMove, { passive: true });
+      window.addEventListener('wheel', this._onWheel, { passive: false });
+      window.addEventListener('touchstart', this._onTouchStart, { passive: true });
+      window.addEventListener('touchmove', this._onTouchMove, { passive: false });
+      window.addEventListener('touchend', this._onTouchEnd, { passive: false });
+      window.addEventListener('touchcancel', this._onTouchCancel, { passive: true });
       // Initial collection + layout happens via slotchange, which fires on mount.
     }
 
@@ -306,8 +333,14 @@
       window.removeEventListener('keydown', this._onKey);
       window.removeEventListener('resize', this._onResize);
       window.removeEventListener('mousemove', this._onMouseMove);
+      window.removeEventListener('wheel', this._onWheel);
+      window.removeEventListener('touchstart', this._onTouchStart);
+      window.removeEventListener('touchmove', this._onTouchMove);
+      window.removeEventListener('touchend', this._onTouchEnd);
+      window.removeEventListener('touchcancel', this._onTouchCancel);
       if (this._hideTimer) clearTimeout(this._hideTimer);
       if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+      if (this._wheelResetTimer) clearTimeout(this._wheelResetTimer);
     }
 
     attributeChangedCallback() {
@@ -502,7 +535,7 @@
           total: this._slides.length,
           slide: this._slides[curr] || null,
           previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
-          reason: reason, // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+          reason: reason, // 'init' | 'keyboard' | 'wheel' | 'click' | 'tap' | 'swipe' | 'api'
         };
         this.dispatchEvent(new CustomEvent('slidechange', {
           detail,
@@ -544,6 +577,109 @@
     _onMouseMove() {
       // Keep overlay visible while mouse moves; hide after idle.
       this._flashOverlay();
+    }
+
+    _isInteractiveNavTarget(e) {
+      const path = typeof e.composedPath === 'function' ? e.composedPath() : [e.target];
+      return path.some((node) => {
+        if (!(node instanceof Element)) return false;
+        return Boolean(node.closest(
+          'a, button, input, textarea, select, summary, [contenteditable], [data-wheel-ignore]'
+        ));
+      });
+    }
+
+    _onWheel(e) {
+      if (e.ctrlKey || e.metaKey || this._isInteractiveNavTarget(e)) return;
+
+      const dx = e.deltaX || 0;
+      const dy = e.deltaY || 0;
+      const primaryDelta = Math.abs(dy) >= Math.abs(dx) ? dy : dx;
+      if (Math.abs(primaryDelta) < 1) return;
+
+      e.preventDefault();
+
+      const now = Date.now();
+      if (now - this._lastWheelTime < WHEEL_COOLDOWN_MS) return;
+
+      this._wheelAccum += primaryDelta;
+      if (this._wheelResetTimer) clearTimeout(this._wheelResetTimer);
+      this._wheelResetTimer = setTimeout(() => {
+        this._wheelAccum = 0;
+      }, WHEEL_RESET_MS);
+
+      if (Math.abs(this._wheelAccum) < WHEEL_THRESHOLD_PX) return;
+
+      const direction = this._wheelAccum > 0 ? 1 : -1;
+      this._wheelAccum = 0;
+      this._lastWheelTime = now;
+      this._go(this._index + direction, 'wheel');
+    }
+
+    _isInteractiveTouchTarget(e) {
+      const path = typeof e.composedPath === 'function' ? e.composedPath() : [e.target];
+      return path.some((node) => {
+        if (!(node instanceof Element)) return false;
+        return Boolean(node.closest(
+          'a, button, input, textarea, select, summary, [contenteditable], [data-swipe-ignore]'
+        ));
+      });
+    }
+
+    _onTouchStart(e) {
+      if (e.touches.length !== 1 || this._isInteractiveTouchTarget(e)) {
+        this._touchTracking = false;
+        return;
+      }
+
+      const touch = e.touches[0];
+      this._touchTracking = true;
+      this._touchStartX = touch.clientX;
+      this._touchStartY = touch.clientY;
+      this._touchLastX = touch.clientX;
+      this._touchLastY = touch.clientY;
+      this._touchStartTime = Date.now();
+    }
+
+    _onTouchMove(e) {
+      if (!this._touchTracking || e.touches.length !== 1) return;
+
+      const touch = e.touches[0];
+      this._touchLastX = touch.clientX;
+      this._touchLastY = touch.clientY;
+
+      const dx = touch.clientX - this._touchStartX;
+      const dy = touch.clientY - this._touchStartY;
+      if (Math.abs(dx) > 12 && Math.abs(dx) > Math.abs(dy)) {
+        e.preventDefault();
+      }
+    }
+
+    _onTouchEnd(e) {
+      if (!this._touchTracking) return;
+
+      const touch = e.changedTouches && e.changedTouches[0];
+      const endX = touch ? touch.clientX : this._touchLastX;
+      const endY = touch ? touch.clientY : this._touchLastY;
+      const dx = endX - this._touchStartX;
+      const dy = endY - this._touchStartY;
+      const elapsed = Date.now() - this._touchStartTime;
+      this._touchTracking = false;
+
+      const isHorizontalSwipe =
+        Math.abs(dx) >= SWIPE_THRESHOLD_PX &&
+        Math.abs(dy) <= SWIPE_RESTRAINT_PX &&
+        Math.abs(dx) > Math.abs(dy) * 1.2 &&
+        elapsed <= SWIPE_MAX_TIME_MS;
+
+      if (!isHorizontalSwipe) return;
+
+      e.preventDefault();
+      this._go(this._index + (dx < 0 ? 1 : -1), 'swipe');
+    }
+
+    _onTouchCancel() {
+      this._touchTracking = false;
     }
 
     _onTapBack(e) {

--- a/html-template.md
+++ b/html-template.md
@@ -107,6 +107,7 @@ Reference architecture for generating slide presentations. Every presentation fo
                 this.stage = document.getElementById('deckStage');
                 this.setupStageScale();
                 this.setupKeyboardNav();
+                this.setupWheelNav();
                 this.setupTouchNav();
                 this.showSlide(0);
             }
@@ -126,8 +127,120 @@ Reference architecture for generating slide presentations. Every presentation fo
                 // Arrow keys, Space, Page Up/Down
             }
 
+            setupWheelNav() {
+                const WHEEL_THRESHOLD = 30;
+                const WHEEL_COOLDOWN = 450;
+                const WHEEL_RESET = 180;
+                let wheelAccum = 0;
+                let lastWheelTime = 0;
+                let wheelResetTimer = null;
+
+                const isInteractiveTarget = (target) => {
+                    return target?.closest?.('a, button, input, textarea, select, summary, [contenteditable], [data-wheel-ignore]');
+                };
+
+                window.addEventListener('wheel', (e) => {
+                    if (e.ctrlKey || e.metaKey || isInteractiveTarget(e.target)) return;
+
+                    const primaryDelta = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+                    if (Math.abs(primaryDelta) < 1) return;
+
+                    e.preventDefault();
+
+                    const now = Date.now();
+                    if (now - lastWheelTime < WHEEL_COOLDOWN) return;
+
+                    wheelAccum += primaryDelta;
+                    clearTimeout(wheelResetTimer);
+                    wheelResetTimer = setTimeout(() => {
+                        wheelAccum = 0;
+                    }, WHEEL_RESET);
+
+                    if (Math.abs(wheelAccum) < WHEEL_THRESHOLD) return;
+
+                    const direction = wheelAccum > 0 ? 1 : -1;
+                    wheelAccum = 0;
+                    lastWheelTime = now;
+                    this.showSlide(this.currentSlide + direction);
+                }, { passive: false });
+            }
+
             setupTouchNav() {
-                // Touch/swipe support for mobile
+                const touchSurface = window;
+                const SWIPE_THRESHOLD = 48;
+                const SWIPE_RESTRAINT = 80;
+                const SWIPE_MAX_TIME = 1200;
+                let startX = 0;
+                let startY = 0;
+                let lastX = 0;
+                let lastY = 0;
+                let startTime = 0;
+                let tracking = false;
+
+                const isInteractiveTarget = (target) => {
+                    const interactive = target?.closest?.('a, button, input, textarea, select, summary, [contenteditable], [data-swipe-ignore]');
+                    return interactive && !interactive.hasAttribute('data-swipe-zone');
+                };
+
+                touchSurface.addEventListener('touchstart', (e) => {
+                    if (e.touches.length !== 1 || isInteractiveTarget(e.target)) {
+                        tracking = false;
+                        return;
+                    }
+
+                    const touch = e.touches[0];
+                    tracking = true;
+                    startX = touch.clientX;
+                    startY = touch.clientY;
+                    lastX = touch.clientX;
+                    lastY = touch.clientY;
+                    startTime = Date.now();
+                }, { passive: true });
+
+                touchSurface.addEventListener('touchmove', (e) => {
+                    if (!tracking || e.touches.length !== 1) return;
+
+                    const touch = e.touches[0];
+                    lastX = touch.clientX;
+                    lastY = touch.clientY;
+
+                    const dx = touch.clientX - startX;
+                    const dy = touch.clientY - startY;
+                    if (Math.abs(dx) > 12 && Math.abs(dx) > Math.abs(dy)) {
+                        e.preventDefault();
+                    }
+                }, { passive: false });
+
+                touchSurface.addEventListener('touchend', (e) => {
+                    if (!tracking) return;
+
+                    const touch = e.changedTouches[0];
+                    const endX = touch ? touch.clientX : lastX;
+                    const endY = touch ? touch.clientY : lastY;
+                    const dx = endX - startX;
+                    const dy = endY - startY;
+                    const elapsed = Date.now() - startTime;
+                    tracking = false;
+
+                    const isHorizontalSwipe =
+                        Math.abs(dx) >= SWIPE_THRESHOLD &&
+                        Math.abs(dy) <= SWIPE_RESTRAINT &&
+                        Math.abs(dx) > Math.abs(dy) * 1.2 &&
+                        elapsed <= SWIPE_MAX_TIME;
+
+                    if (!isHorizontalSwipe) return;
+
+                    e.preventDefault();
+                    if (dx < 0) {
+                        this.showSlide(this.currentSlide + 1);
+                    } else {
+                        this.showSlide(this.currentSlide - 1);
+                    }
+                }, { passive: false });
+
+                touchSurface.addEventListener('touchcancel', () => {
+                    tracking = false;
+                }, { passive: true });
             }
 
             showSlide(index) {

--- a/plugins/frontend-slides/skills/frontend-slides/SKILL.md
+++ b/plugins/frontend-slides/skills/frontend-slides/SKILL.md
@@ -264,7 +264,7 @@ When converting PowerPoint files:
 2. **Open** — Use `open [filename].html` to launch in browser
 3. **Summarize** — Tell the user:
    - File location, style name, slide count
-   - Navigation: Arrow keys, Space, swipe/tap if enabled
+   - Navigation: Arrow keys, Space, short mouse wheel, horizontal swipe, and tap zones
    - How to customize: `:root` CSS variables for colors, font link for typography, `.reveal` class for animations
    - Inline text editing is available: Hover top-left corner or press E to enter edit mode, click any text to edit, Ctrl+S to save
    - Offer the natural post-draft actions: ask for revisions, edit text directly in the browser, or export/share

--- a/plugins/frontend-slides/skills/frontend-slides/bold-template-pack/deck-stage.js
+++ b/plugins/frontend-slides/skills/frontend-slides/bold-template-pack/deck-stage.js
@@ -30,7 +30,7 @@
  *     e.detail.total         // total slide count
  *     e.detail.slide         // the new active slide element
  *     e.detail.previousSlide // the prior slide element, or null on init
- *     e.detail.reason        // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+ *     e.detail.reason        // 'init' | 'keyboard' | 'wheel' | 'click' | 'tap' | 'swipe' | 'api'
  *   });
  *
  * Persistence: none at the deck level. The host app keeps the current slide
@@ -53,6 +53,12 @@
   const DESIGN_W_DEFAULT = 1920;
   const DESIGN_H_DEFAULT = 1080;
   const OVERLAY_HIDE_MS = 1800;
+  const SWIPE_THRESHOLD_PX = 48;
+  const SWIPE_RESTRAINT_PX = 80;
+  const SWIPE_MAX_TIME_MS = 1200;
+  const WHEEL_THRESHOLD_PX = 30;
+  const WHEEL_COOLDOWN_MS = 450;
+  const WHEEL_RESET_MS = 180;
   const VALIDATE_ATTR = 'no_overflowing_text,no_overlapping_text,slide_sized_text';
 
   const pad2 = (n) => String(n).padStart(2, '0');
@@ -66,6 +72,8 @@
       color: #fff;
       font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
       overflow: hidden;
+      overscroll-behavior: none;
+      touch-action: pan-y;
     }
 
     .stage {
@@ -276,11 +284,25 @@
       this._notes = [];
       this._hideTimer = null;
       this._mouseIdleTimer = null;
+      this._wheelAccum = 0;
+      this._lastWheelTime = 0;
+      this._wheelResetTimer = null;
+      this._touchTracking = false;
+      this._touchStartX = 0;
+      this._touchStartY = 0;
+      this._touchLastX = 0;
+      this._touchLastY = 0;
+      this._touchStartTime = 0;
 
       this._onKey = this._onKey.bind(this);
       this._onResize = this._onResize.bind(this);
       this._onSlotChange = this._onSlotChange.bind(this);
       this._onMouseMove = this._onMouseMove.bind(this);
+      this._onWheel = this._onWheel.bind(this);
+      this._onTouchStart = this._onTouchStart.bind(this);
+      this._onTouchMove = this._onTouchMove.bind(this);
+      this._onTouchEnd = this._onTouchEnd.bind(this);
+      this._onTouchCancel = this._onTouchCancel.bind(this);
       this._onTapBack = this._onTapBack.bind(this);
       this._onTapForward = this._onTapForward.bind(this);
     }
@@ -299,6 +321,11 @@
       window.addEventListener('keydown', this._onKey);
       window.addEventListener('resize', this._onResize);
       window.addEventListener('mousemove', this._onMouseMove, { passive: true });
+      window.addEventListener('wheel', this._onWheel, { passive: false });
+      window.addEventListener('touchstart', this._onTouchStart, { passive: true });
+      window.addEventListener('touchmove', this._onTouchMove, { passive: false });
+      window.addEventListener('touchend', this._onTouchEnd, { passive: false });
+      window.addEventListener('touchcancel', this._onTouchCancel, { passive: true });
       // Initial collection + layout happens via slotchange, which fires on mount.
     }
 
@@ -306,8 +333,14 @@
       window.removeEventListener('keydown', this._onKey);
       window.removeEventListener('resize', this._onResize);
       window.removeEventListener('mousemove', this._onMouseMove);
+      window.removeEventListener('wheel', this._onWheel);
+      window.removeEventListener('touchstart', this._onTouchStart);
+      window.removeEventListener('touchmove', this._onTouchMove);
+      window.removeEventListener('touchend', this._onTouchEnd);
+      window.removeEventListener('touchcancel', this._onTouchCancel);
       if (this._hideTimer) clearTimeout(this._hideTimer);
       if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+      if (this._wheelResetTimer) clearTimeout(this._wheelResetTimer);
     }
 
     attributeChangedCallback() {
@@ -502,7 +535,7 @@
           total: this._slides.length,
           slide: this._slides[curr] || null,
           previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
-          reason: reason, // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+          reason: reason, // 'init' | 'keyboard' | 'wheel' | 'click' | 'tap' | 'swipe' | 'api'
         };
         this.dispatchEvent(new CustomEvent('slidechange', {
           detail,
@@ -544,6 +577,109 @@
     _onMouseMove() {
       // Keep overlay visible while mouse moves; hide after idle.
       this._flashOverlay();
+    }
+
+    _isInteractiveNavTarget(e) {
+      const path = typeof e.composedPath === 'function' ? e.composedPath() : [e.target];
+      return path.some((node) => {
+        if (!(node instanceof Element)) return false;
+        return Boolean(node.closest(
+          'a, button, input, textarea, select, summary, [contenteditable], [data-wheel-ignore]'
+        ));
+      });
+    }
+
+    _onWheel(e) {
+      if (e.ctrlKey || e.metaKey || this._isInteractiveNavTarget(e)) return;
+
+      const dx = e.deltaX || 0;
+      const dy = e.deltaY || 0;
+      const primaryDelta = Math.abs(dy) >= Math.abs(dx) ? dy : dx;
+      if (Math.abs(primaryDelta) < 1) return;
+
+      e.preventDefault();
+
+      const now = Date.now();
+      if (now - this._lastWheelTime < WHEEL_COOLDOWN_MS) return;
+
+      this._wheelAccum += primaryDelta;
+      if (this._wheelResetTimer) clearTimeout(this._wheelResetTimer);
+      this._wheelResetTimer = setTimeout(() => {
+        this._wheelAccum = 0;
+      }, WHEEL_RESET_MS);
+
+      if (Math.abs(this._wheelAccum) < WHEEL_THRESHOLD_PX) return;
+
+      const direction = this._wheelAccum > 0 ? 1 : -1;
+      this._wheelAccum = 0;
+      this._lastWheelTime = now;
+      this._go(this._index + direction, 'wheel');
+    }
+
+    _isInteractiveTouchTarget(e) {
+      const path = typeof e.composedPath === 'function' ? e.composedPath() : [e.target];
+      return path.some((node) => {
+        if (!(node instanceof Element)) return false;
+        return Boolean(node.closest(
+          'a, button, input, textarea, select, summary, [contenteditable], [data-swipe-ignore]'
+        ));
+      });
+    }
+
+    _onTouchStart(e) {
+      if (e.touches.length !== 1 || this._isInteractiveTouchTarget(e)) {
+        this._touchTracking = false;
+        return;
+      }
+
+      const touch = e.touches[0];
+      this._touchTracking = true;
+      this._touchStartX = touch.clientX;
+      this._touchStartY = touch.clientY;
+      this._touchLastX = touch.clientX;
+      this._touchLastY = touch.clientY;
+      this._touchStartTime = Date.now();
+    }
+
+    _onTouchMove(e) {
+      if (!this._touchTracking || e.touches.length !== 1) return;
+
+      const touch = e.touches[0];
+      this._touchLastX = touch.clientX;
+      this._touchLastY = touch.clientY;
+
+      const dx = touch.clientX - this._touchStartX;
+      const dy = touch.clientY - this._touchStartY;
+      if (Math.abs(dx) > 12 && Math.abs(dx) > Math.abs(dy)) {
+        e.preventDefault();
+      }
+    }
+
+    _onTouchEnd(e) {
+      if (!this._touchTracking) return;
+
+      const touch = e.changedTouches && e.changedTouches[0];
+      const endX = touch ? touch.clientX : this._touchLastX;
+      const endY = touch ? touch.clientY : this._touchLastY;
+      const dx = endX - this._touchStartX;
+      const dy = endY - this._touchStartY;
+      const elapsed = Date.now() - this._touchStartTime;
+      this._touchTracking = false;
+
+      const isHorizontalSwipe =
+        Math.abs(dx) >= SWIPE_THRESHOLD_PX &&
+        Math.abs(dy) <= SWIPE_RESTRAINT_PX &&
+        Math.abs(dx) > Math.abs(dy) * 1.2 &&
+        elapsed <= SWIPE_MAX_TIME_MS;
+
+      if (!isHorizontalSwipe) return;
+
+      e.preventDefault();
+      this._go(this._index + (dx < 0 ? 1 : -1), 'swipe');
+    }
+
+    _onTouchCancel() {
+      this._touchTracking = false;
     }
 
     _onTapBack(e) {

--- a/plugins/frontend-slides/skills/frontend-slides/html-template.md
+++ b/plugins/frontend-slides/skills/frontend-slides/html-template.md
@@ -107,6 +107,7 @@ Reference architecture for generating slide presentations. Every presentation fo
                 this.stage = document.getElementById('deckStage');
                 this.setupStageScale();
                 this.setupKeyboardNav();
+                this.setupWheelNav();
                 this.setupTouchNav();
                 this.showSlide(0);
             }
@@ -126,8 +127,120 @@ Reference architecture for generating slide presentations. Every presentation fo
                 // Arrow keys, Space, Page Up/Down
             }
 
+            setupWheelNav() {
+                const WHEEL_THRESHOLD = 30;
+                const WHEEL_COOLDOWN = 450;
+                const WHEEL_RESET = 180;
+                let wheelAccum = 0;
+                let lastWheelTime = 0;
+                let wheelResetTimer = null;
+
+                const isInteractiveTarget = (target) => {
+                    return target?.closest?.('a, button, input, textarea, select, summary, [contenteditable], [data-wheel-ignore]');
+                };
+
+                window.addEventListener('wheel', (e) => {
+                    if (e.ctrlKey || e.metaKey || isInteractiveTarget(e.target)) return;
+
+                    const primaryDelta = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+                    if (Math.abs(primaryDelta) < 1) return;
+
+                    e.preventDefault();
+
+                    const now = Date.now();
+                    if (now - lastWheelTime < WHEEL_COOLDOWN) return;
+
+                    wheelAccum += primaryDelta;
+                    clearTimeout(wheelResetTimer);
+                    wheelResetTimer = setTimeout(() => {
+                        wheelAccum = 0;
+                    }, WHEEL_RESET);
+
+                    if (Math.abs(wheelAccum) < WHEEL_THRESHOLD) return;
+
+                    const direction = wheelAccum > 0 ? 1 : -1;
+                    wheelAccum = 0;
+                    lastWheelTime = now;
+                    this.showSlide(this.currentSlide + direction);
+                }, { passive: false });
+            }
+
             setupTouchNav() {
-                // Touch/swipe support for mobile
+                const touchSurface = window;
+                const SWIPE_THRESHOLD = 48;
+                const SWIPE_RESTRAINT = 80;
+                const SWIPE_MAX_TIME = 1200;
+                let startX = 0;
+                let startY = 0;
+                let lastX = 0;
+                let lastY = 0;
+                let startTime = 0;
+                let tracking = false;
+
+                const isInteractiveTarget = (target) => {
+                    const interactive = target?.closest?.('a, button, input, textarea, select, summary, [contenteditable], [data-swipe-ignore]');
+                    return interactive && !interactive.hasAttribute('data-swipe-zone');
+                };
+
+                touchSurface.addEventListener('touchstart', (e) => {
+                    if (e.touches.length !== 1 || isInteractiveTarget(e.target)) {
+                        tracking = false;
+                        return;
+                    }
+
+                    const touch = e.touches[0];
+                    tracking = true;
+                    startX = touch.clientX;
+                    startY = touch.clientY;
+                    lastX = touch.clientX;
+                    lastY = touch.clientY;
+                    startTime = Date.now();
+                }, { passive: true });
+
+                touchSurface.addEventListener('touchmove', (e) => {
+                    if (!tracking || e.touches.length !== 1) return;
+
+                    const touch = e.touches[0];
+                    lastX = touch.clientX;
+                    lastY = touch.clientY;
+
+                    const dx = touch.clientX - startX;
+                    const dy = touch.clientY - startY;
+                    if (Math.abs(dx) > 12 && Math.abs(dx) > Math.abs(dy)) {
+                        e.preventDefault();
+                    }
+                }, { passive: false });
+
+                touchSurface.addEventListener('touchend', (e) => {
+                    if (!tracking) return;
+
+                    const touch = e.changedTouches[0];
+                    const endX = touch ? touch.clientX : lastX;
+                    const endY = touch ? touch.clientY : lastY;
+                    const dx = endX - startX;
+                    const dy = endY - startY;
+                    const elapsed = Date.now() - startTime;
+                    tracking = false;
+
+                    const isHorizontalSwipe =
+                        Math.abs(dx) >= SWIPE_THRESHOLD &&
+                        Math.abs(dy) <= SWIPE_RESTRAINT &&
+                        Math.abs(dx) > Math.abs(dy) * 1.2 &&
+                        elapsed <= SWIPE_MAX_TIME;
+
+                    if (!isHorizontalSwipe) return;
+
+                    e.preventDefault();
+                    if (dx < 0) {
+                        this.showSlide(this.currentSlide + 1);
+                    } else {
+                        this.showSlide(this.currentSlide - 1);
+                    }
+                }, { passive: false });
+
+                touchSurface.addEventListener('touchcancel', () => {
+                    tracking = false;
+                }, { passive: true });
             }
 
             showSlide(index) {

--- a/plugins/frontend-slides/skills/frontend-slides/viewport-base.css
+++ b/plugins/frontend-slides/skills/frontend-slides/viewport-base.css
@@ -20,6 +20,8 @@ body {
     inset: 0;
     overflow: hidden;
     background: var(--stage-bg, #000);
+    overscroll-behavior: none;
+    touch-action: pan-y;
 }
 
 /* 3. Fixed 16:9 design canvas.
@@ -33,6 +35,7 @@ body {
     overflow: hidden;
     transform-origin: 0 0;
     background: var(--slide-bg, #fff);
+    touch-action: pan-y;
 }
 
 /* 4. Slides stack inside the fixed stage.

--- a/tests/touch-navigation.test.mjs
+++ b/tests/touch-navigation.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('html template includes concrete touch swipe and wheel navigation', async () => {
+  const template = await readFile(resolve(rootDir, 'html-template.md'), 'utf8');
+
+  assert.match(template, /this\.setupWheelNav\(\)/);
+  assert.match(template, /setupWheelNav\(\)\s*\{[\s\S]*wheel/);
+  assert.match(template, /setupWheelNav\(\)\s*\{[\s\S]*WHEEL_THRESHOLD/);
+  assert.match(template, /setupWheelNav\(\)\s*\{[\s\S]*this\.showSlide\(this\.currentSlide \+ direction\)/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*touchstart/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*const touchSurface = window/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*data-swipe-zone/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*touchend/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*SWIPE_THRESHOLD/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*this\.showSlide\(this\.currentSlide \+ 1\)/);
+  assert.match(template, /setupTouchNav\(\)\s*\{[\s\S]*this\.showSlide\(this\.currentSlide - 1\)/);
+});
+
+test('deck-stage changes slides on horizontal touch swipes', async (t) => {
+  const nodeMajor = Number(process.versions.node.split('.')[0]);
+  if (nodeMajor < 18) {
+    t.skip('Playwright requires Node.js 18 or newer');
+    return;
+  }
+
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch (error) {
+    t.skip(`Playwright is unavailable: ${error.message}`);
+    return;
+  }
+
+  const deckStageScript = await readFile(resolve(rootDir, 'bold-template-pack/deck-stage.js'), 'utf8');
+  const html = `<!doctype html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>
+          html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+          section { background: white; color: black; font: 80px sans-serif; }
+        </style>
+      </head>
+      <body>
+        <script>${deckStageScript}</script>
+        <deck-stage>
+          <section data-label="One">One</section>
+          <section data-label="Two">Two</section>
+          <section data-label="Three">Three</section>
+        </deck-stage>
+      </body>
+    </html>`;
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(async () => {
+    await browser.close();
+  });
+
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  const client = await context.newCDPSession(page);
+
+  await page.setContent(html, { waitUntil: 'load' });
+  await page.waitForFunction(() => {
+    const deck = document.querySelector('deck-stage');
+    return deck && deck.length === 3 && deck.index === 0;
+  });
+
+  const swipe = async (fromX, toX, y = 420) => {
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: fromX, y }],
+    });
+    await page.waitForTimeout(40);
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: (fromX + toX) / 2, y }],
+    });
+    await page.waitForTimeout(40);
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: toX, y }],
+    });
+    await page.waitForTimeout(40);
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    });
+    await page.waitForTimeout(80);
+  };
+
+  await swipe(330, 80);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 1);
+
+  await swipe(80, 330);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 0);
+
+  await swipe(330, 300);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 0);
+});
+
+test('deck-stage changes slides on short mouse wheel gestures', async (t) => {
+  const nodeMajor = Number(process.versions.node.split('.')[0]);
+  if (nodeMajor < 18) {
+    t.skip('Playwright requires Node.js 18 or newer');
+    return;
+  }
+
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch (error) {
+    t.skip(`Playwright is unavailable: ${error.message}`);
+    return;
+  }
+
+  const deckStageScript = await readFile(resolve(rootDir, 'bold-template-pack/deck-stage.js'), 'utf8');
+  const html = `<!doctype html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>
+          html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+          section { background: white; color: black; font: 80px sans-serif; }
+        </style>
+      </head>
+      <body>
+        <script>${deckStageScript}</script>
+        <deck-stage>
+          <section data-label="One">One</section>
+          <section data-label="Two">Two</section>
+          <section data-label="Three">Three</section>
+        </deck-stage>
+      </body>
+    </html>`;
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(async () => {
+    await browser.close();
+  });
+
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  await page.setContent(html, { waitUntil: 'load' });
+  await page.waitForFunction(() => {
+    const deck = document.querySelector('deck-stage');
+    return deck && deck.length === 3 && deck.index === 0;
+  });
+
+  await page.mouse.wheel(0, 60);
+  await page.waitForTimeout(120);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 1);
+
+  await page.waitForTimeout(520);
+  await page.mouse.wheel(0, -60);
+  await page.waitForTimeout(120);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 0);
+
+  await page.waitForTimeout(520);
+  await page.mouse.wheel(0, 10);
+  await page.waitForTimeout(120);
+  assert.equal(await page.$eval('deck-stage', (deck) => deck.index), 0);
+});

--- a/viewport-base.css
+++ b/viewport-base.css
@@ -20,6 +20,8 @@ body {
     inset: 0;
     overflow: hidden;
     background: var(--stage-bg, #000);
+    overscroll-behavior: none;
+    touch-action: pan-y;
 }
 
 /* 3. Fixed 16:9 design canvas.
@@ -33,6 +35,7 @@ body {
     overflow: hidden;
     transform-origin: 0 0;
     background: var(--slide-bg, #fff);
+    touch-action: pan-y;
 }
 
 /* 4. Slides stack inside the fixed stage.


### PR DESCRIPTION
## Summary

- Add concrete horizontal swipe support for generated fixed-stage slide decks
- Restore short mouse-wheel navigation with threshold/cooldown handling
- Keep root skill files and packaged plugin mirror in sync
- Add Node/Playwright regression coverage for touch swipe and wheel gestures

## Testing

- `NODE_PATH=/Users/zhangyingze/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules /Users/zhangyingze/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test tests/touch-navigation.test.mjs`
- `git diff --check`

## Notes

Direct push to `origin` was not permitted for the current GitHub account, so this PR is opened from the `edward-zyz/frontend-slides` fork into `zarazhangrui/frontend-slides:main`.